### PR TITLE
set pagination pagesCount so it is a minimum of 1

### DIFF
--- a/src/bindings/paginationBinding.js
+++ b/src/bindings/paginationBinding.js
@@ -81,7 +81,7 @@ function Pager(data) {
         var total = ko.unwrap(self.totalCount),
             pageSize = ko.unwrap(self.pageSize);
 
-        return Math.ceil(total / pageSize);
+        return Math.max(Math.ceil(total / pageSize), 1);
     });
 
     self.isBackDisabled = ko.computed(function () {


### PR DESCRIPTION
When totalCount == 0, it results in a pagesCount of 0, and will produce negative page numbers.  Setting the pagesCount to be *at least* 1 resolves this issue.